### PR TITLE
Change from bulky default image to slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.13-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Updated the python version from 3.9 to 3.13 and docker image variant from base to -slim.